### PR TITLE
Add macOS-specific home configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,11 +9,12 @@
 
   outputs = { self, nixpkgs, home-manager, ... }:
     let
-      system = "x86_64-linux";
+      linuxSystem = "x86_64-linux";
+      darwinSystem = "aarch64-darwin";
       username = "garo";
     in {
       nixosConfigurations.main = nixpkgs.lib.nixosSystem {
-        system = system;
+        system = linuxSystem;
         modules = [
           ./configuration.nix
           home-manager.nixosModules.home-manager
@@ -22,6 +23,13 @@
             home-manager.useUserPackages = true;
             home-manager.users.${username} = import ./home.nix;
           }
+        ];
+      };
+
+      homeConfigurations."${username}@macbook" = home-manager.lib.homeManagerConfiguration {
+        pkgs = import nixpkgs { system = darwinSystem; };
+        modules = [
+          ./home-darwin.nix
         ];
       };
     };

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -1,0 +1,51 @@
+{ pkgs, ... }:
+let
+  sharedPackages = with pkgs; [
+    nodejs_24
+    pnpm
+    bun
+    poetry
+    rust
+    cargo
+    k9s
+    helm
+    kubectl
+    tmux
+    jq
+    direnv
+    nix-direnv
+    ripgrep
+  ];
+in
+{
+  home.username = "garo";
+  home.homeDirectory = "/Users/garo";
+  home.stateVersion = "25.05";
+
+  home.packages = sharedPackages;
+
+  imports = [
+    ./modules/shell/shell.nix
+    ./modules/term/term.nix
+    ./modules/tool/tool.nix
+  ];
+
+  zsh-config.enable = true;
+  ghostty.enable = true;
+  tmux.enable = true;
+  k9s.enable = true;
+
+  sxhkd.enable = false;
+  dunst.enable = false;
+
+  programs.git = {
+    enable = true;
+    userName = "typegaro";
+    userEmail = "lorenzo.di.giovanni00@gmail.com";
+    aliases = {
+      s = "status";
+      au = "add -u";
+      cvn = "commit -m\"very nice\"";
+    };
+  };
+}

--- a/modules/tool/dunst.nix
+++ b/modules/tool/dunst.nix
@@ -2,7 +2,7 @@
 {
   options."dunst".enable = lib.mkEnableOption "Dunst notification daemon";
 
-  config = lib.mkIf config."dunst".enable {
+  config = lib.mkIf (config."dunst".enable && pkgs.stdenv.hostPlatform.isLinux) {
     services.dunst = {
       enable = true;
       package = pkgs.dunst;

--- a/modules/tool/sxhkd.nix
+++ b/modules/tool/sxhkd.nix
@@ -2,7 +2,7 @@
 
 {
   options."sxhkd".enable = lib.mkEnableOption "SXHKD keybindings";
-  config = lib.mkIf config."sxhkd".enable {
+  config = lib.mkIf (config."sxhkd".enable && pkgs.stdenv.hostPlatform.isLinux) {
     services.sxhkd = {
       enable = true;
       keybindings = {


### PR DESCRIPTION
## Summary
- restore the Linux Home Manager configuration to its original Linux-only settings
- add a dedicated `home-darwin.nix` module for macOS that reuses the shared Home Manager modules but tailors packages and options for Darwin
- point the macOS home configuration output in the flake to the new module

## Testing
- not run (nix command is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d9ac95922c8332ada21b1eee771e58